### PR TITLE
Add basic service plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Flock-It is an all-in-one pentest automation framework designed to streamline th
 
 - 🧪 Internal, external, and web recon support
 - 🔌 Plugin-based architecture
+- Includes built-in plugins for HTTP, FTP, SSH and SMB
 - 🪄 Auto-generates custom plugins using LLM (Ollama)
 - 🧠 AI-enhanced reporting and remediation context
 - 📦 Auto SMB uploads to shared drives
@@ -68,6 +69,12 @@ PR00099/
 - Manages registration and loading of static and AI-generated plugins
 - Supports autoloading from `modules/plugins`
 - Registers plugins using `.should_run()` matching logic
+### 📦 Built-in Plugins
+- `http_scan` - grabs HTTP banner
+- `ftp_scan` - captures FTP welcome message
+- `ssh_scan` - collects SSH server banner
+- `smb_scan` - lists SMB shares anonymously
+
 
 ### 🦉 Owl (AI Reporting & Summary)
 - Creates a rich markdown report (`report.md`)

--- a/modules/plugins/__init__.py
+++ b/modules/plugins/__init__.py
@@ -1,13 +1,17 @@
 class ScanPlugin:
-    """
-    Base class for scan plugins.
-    Each plugin should define a unique name, a condition (should_run) and execution logic (run).
-    """
+    """Base class for all scanning plugins."""
+
+    # Short unique plugin name
     name = "base_plugin"
+    # Optional semantic version
     version = 1
+    # Human readable description
+    description = ""
 
     def should_run(self, host, port, port_data):
+        """Return True if plugin should execute for this port."""
         return False
 
     def run(self, host, port, port_data):
-        return None
+        """Execute plugin logic and return a result dictionary."""
+        return {}

--- a/modules/plugins/ftp_scan.py
+++ b/modules/plugins/ftp_scan.py
@@ -1,0 +1,22 @@
+from modules.plugins import ScanPlugin
+from utils.common import print_status
+import socket
+
+class FtpScan(ScanPlugin):
+    """Grab banner from FTP service."""
+    name = "ftp_scan"
+    description = "Enumerate FTP banner"
+
+    def should_run(self, host, port, port_data):
+        return port == 21 or port_data.get("service") == "ftp"
+
+    def run(self, host, port, port_data):
+        try:
+            with socket.create_connection((host, port), timeout=3) as s:
+                banner = s.recv(1024).decode("utf-8", "ignore").strip()
+                s.sendall(b"QUIT\r\n")
+                print_status(f"[FTPScan] {banner}", "info")
+                return {"banner": banner}
+        except Exception as e:
+            print_status(f"[FTPScan] Error: {e}", "warning")
+            return {"error": str(e)}

--- a/modules/plugins/http_scan.py
+++ b/modules/plugins/http_scan.py
@@ -1,0 +1,24 @@
+from modules.plugins import ScanPlugin
+from utils.common import print_status
+import socket
+
+class HttpScan(ScanPlugin):
+    """Simple HTTP banner grabber."""
+    name = "http_scan"
+    description = "Retrieve HTTP response status line"
+
+    def should_run(self, host, port, port_data):
+        return port in (80, 8080) or port_data.get("service") == "http"
+
+    def run(self, host, port, port_data):
+        try:
+            with socket.create_connection((host, port), timeout=3) as s:
+                request = f"HEAD / HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n"
+                s.sendall(request.encode("utf-8"))
+                response = s.recv(1024).decode("utf-8", "ignore")
+                first_line = response.splitlines()[0] if response else ""
+                print_status(f"[HTTPScan] {first_line}", "info")
+                return {"banner": first_line}
+        except Exception as e:
+            print_status(f"[HTTPScan] Error: {e}", "warning")
+            return {"error": str(e)}

--- a/modules/plugins/smb_scan.py
+++ b/modules/plugins/smb_scan.py
@@ -1,0 +1,24 @@
+from modules.plugins import ScanPlugin
+from utils.common import print_status
+from impacket.smbconnection import SMBConnection
+
+class SmbScan(ScanPlugin):
+    """Enumerate SMB shares anonymously."""
+    name = "smb_scan"
+    description = "List SMB shares via anonymous login"
+
+    def should_run(self, host, port, port_data):
+        return port == 445 or port_data.get("service") in ("microsoft-ds", "smb")
+
+    def run(self, host, port, port_data):
+        try:
+            conn = SMBConnection(host, host)
+            conn.login("", "")
+            shares = conn.listShares()
+            share_names = [s.getName() for s in shares]
+            conn.logoff()
+            print_status(f"[SMBScan] Shares: {', '.join(share_names)}", "info")
+            return {"shares": share_names}
+        except Exception as e:
+            print_status(f"[SMBScan] Error: {e}", "warning")
+            return {"error": str(e)}

--- a/modules/plugins/ssh_scan.py
+++ b/modules/plugins/ssh_scan.py
@@ -1,0 +1,21 @@
+from modules.plugins import ScanPlugin
+from utils.common import print_status
+import socket
+
+class SshScan(ScanPlugin):
+    """Collect SSH banner."""
+    name = "ssh_scan"
+    description = "Retrieve SSH server banner"
+
+    def should_run(self, host, port, port_data):
+        return port == 22 or port_data.get("service") == "ssh"
+
+    def run(self, host, port, port_data):
+        try:
+            with socket.create_connection((host, port), timeout=3) as s:
+                banner = s.recv(1024).decode("utf-8", "ignore").strip()
+                print_status(f"[SSHScan] {banner}", "info")
+                return {"banner": banner}
+        except Exception as e:
+            print_status(f"[SSHScan] Error: {e}", "warning")
+            return {"error": str(e)}


### PR DESCRIPTION
## Summary
- provide built-in plugins for HTTP/FTP/SSH/SMB
- extend `ScanPlugin` base class with description
- mention built-in plugins in README

## Testing
- `python3 -m py_compile modules/plugins/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6841b5a88080832b8b0291fae64a1b93