### PR TITLE
Add looping scans and result server

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Available flags:
 - `--ascii`: Show ASCII network map
 - `--output <file>`: Output report file (default: `report.md`)
 - `--mode <quick|full>`: Select scan depth mode (default: `quick`)
+- `--loop-interval <minutes>`: Run scans continuously with the given interval
+- `--server-url <url>`: POST zipped results to this URL after each run
 
 ### 🧠 Automation Flags
 - `--auto`: Auto-accept all prompts (overrides others)
@@ -149,6 +151,16 @@ Target path is:
 smb://<IP>/Media/Projects/<project_name>/<project_name>.zip
 ```
 You’ll be prompted to enter credentials.
+
+## 🌐 Result Collector Server
+
+A basic Flask server (`results_server.py`) is included to receive zipped scan results. Run it on a system with network access:
+
+```bash
+python3 results_server.py
+```
+
+Configure Flock-It with `--server-url http://<server>:8000/upload` to send results after each loop.
 
 ---
 

--- a/modules/preflight.py
+++ b/modules/preflight.py
@@ -276,11 +276,17 @@ class PreFlight:
         Write the accumulated SCAN_RESULTS into an XML file in the project folder.
         The XML structure includes mode sections and for each target, its details.
         """
-        root = ET.Element("ScanResults")
-        timestamp = ET.SubElement(root, "Timestamp")
-        timestamp.text = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        xml_file = os.path.join(self.project_folder, "scan_results.xml")
+        if os.path.exists(xml_file):
+            tree = ET.parse(xml_file)
+            root = tree.getroot()
+        else:
+            root = ET.Element("ScanResults")
+
+        run_elem = ET.SubElement(root, "Run", timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+
         for mode, results in SCAN_RESULTS.items():
-            mode_elem = ET.SubElement(root, "Mode", name=mode)
+            mode_elem = ET.SubElement(run_elem, "Mode", name=mode)
             for entry in results:
                 if "external_ip" in entry:
                     ext_elem = ET.SubElement(mode_elem, "ExternalIP")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ impacket
 python-nmap
 ollama
 openai
+flask

--- a/results_server.py
+++ b/results_server.py
@@ -1,0 +1,22 @@
+from flask import Flask, request, abort
+import os
+from datetime import datetime
+
+UPLOAD_DIR = "received_results"
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+app = Flask(__name__)
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        abort(400, 'Missing file')
+    f = request.files['file']
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    filename = f.filename or 'results.zip'
+    save_path = os.path.join(UPLOAD_DIR, f"{timestamp}_{filename}")
+    f.save(save_path)
+    return 'OK', 200
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/utils/common.py
+++ b/utils/common.py
@@ -297,3 +297,18 @@ def save_scan_output(host, filename, content, base_dir=None):
         print_status(f"[!] Failed to write {file_path}: {e}", "error")
 
 
+
+
+
+def send_results_to_server(zip_path, server_url):
+    """Upload zipped results to a remote server via HTTP POST"""
+    try:
+        with open(zip_path, "rb") as f:
+            files = {"file": (os.path.basename(zip_path), f)}
+            resp = requests.post(server_url, files=files, timeout=10)
+        if resp.status_code == 200:
+            print_status(f"[+] Results uploaded to {server_url}", "success")
+        else:
+            print_status(f"[!] Server responded with {resp.status_code}", "warning")
+    except Exception as e:
+        print_status(f"[!] Failed to upload results: {e}", "error")


### PR DESCRIPTION
## Summary
- add ability to repeat scans using `--loop-interval`
- upload zipped results via `--server-url`
- append XML results for each run
- provide small Flask `results_server.py` to receive uploads
- include Flask in requirements

## Testing
- `python3 -m py_compile flockit.py modules/*.py utils/*.py results_server.py`

------
https://chatgpt.com/codex/tasks/task_e_684c023b19f4832bb3f1a2de1ecd0716